### PR TITLE
feat(api): return dates as UTC ISO string in freerooms endpoint

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,11 +13,13 @@
     "@sentry/node": "7.42.0",
     "@sentry/tracing": "7.42.0",
     "cors": "2.8.5",
-    "express": "4.18.2"
+    "express": "4.18.2",
+    "luxon": "^3.3.0"
   },
   "devDependencies": {
     "@types/cors": "2.8.13",
     "@types/express": "4.17.17",
+    "@types/luxon": "^3.2.0",
     "prettier": "2.8.4",
     "typescript": "4.9.5"
   }

--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "@sentry/node": "7.42.0",
     "@sentry/tracing": "7.42.0",
     "cors": "2.8.5",
-    "dayjs": "^1.11.7",
+    "dayjs": "1.11.7",
     "express": "4.18.2"
   },
   "devDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -13,13 +13,13 @@
     "@sentry/node": "7.42.0",
     "@sentry/tracing": "7.42.0",
     "cors": "2.8.5",
-    "express": "4.18.2",
-    "luxon": "^3.3.0"
+    "date-fns": "^2.29.3",
+    "date-fns-tz": "^2.0.0",
+    "express": "4.18.2"
   },
   "devDependencies": {
     "@types/cors": "2.8.13",
     "@types/express": "4.17.17",
-    "@types/luxon": "^3.2.0",
     "prettier": "2.8.4",
     "typescript": "4.9.5"
   }

--- a/api/package.json
+++ b/api/package.json
@@ -13,8 +13,7 @@
     "@sentry/node": "7.42.0",
     "@sentry/tracing": "7.42.0",
     "cors": "2.8.5",
-    "date-fns": "^2.29.3",
-    "date-fns-tz": "^2.0.0",
+    "dayjs": "^1.11.7",
     "express": "4.18.2"
   },
   "devDependencies": {

--- a/api/src/freerooms/index.ts
+++ b/api/src/freerooms/index.ts
@@ -18,7 +18,7 @@ const getFreeroomsData = (req: express.Request, res: express.Response) => {
     const term = req.params.termId.substring(5);
     const termData = data.timetableData[term];
 
-    // Get the start date for the term as a DateTime object
+    // Get the start date for the term as a tz-aware Dayjs object
     const startDT = dayjs.tz(getTermStartDate(term), "DD/MM/YYYY", "Australia/Sydney");
 
     let freeroomsData = {};
@@ -51,6 +51,7 @@ const getFreeroomsData = (req: express.Request, res: express.Response) => {
           let endTime = timeElement["time"]["end"];
           let weeks = timeElement["weeks"];
 
+          // Set the day of the week in Dayjs object
           const dayDT = startDT.day(DAYS.indexOf(day));
 
           // case 1: "weeks": "11" (single week)
@@ -164,7 +165,7 @@ const inputData = (
 
 /**
  * Converts a class start/end time to UTC ISO format (YYYY-MM-DDThh:mm:ssZ)
- * @param day day as a luxon DateTime object
+ * @param day day of the class as a Dayjs object
  * @param time time in 24hr HH:MM format
  */
 const toUTCString = (

--- a/api/src/freerooms/index.ts
+++ b/api/src/freerooms/index.ts
@@ -56,8 +56,8 @@ const getFreeroomsData = (req: express.Request, res: express.Response) => {
 
               // turn string into a decimal number after splitting
               // it will be converted back into a string when used as a key in the object
-              let startWeek = parseInt(startRange);
-              let endWeek = parseInt(endRange);
+              let startWeek = parseWeek(startRange);
+              let endWeek = parseWeek(endRange);
 
               for (let currentWeek = startWeek; currentWeek <= endWeek; currentWeek++) {
                 inputData(
@@ -76,7 +76,8 @@ const getFreeroomsData = (req: express.Request, res: express.Response) => {
             } else {
               // case 2: week is an integer eg. 5
               // turn string into a decimal number for consistency with case 1
-              let currentWeek = parseInt(allWeeks[week]);
+              let currentWeek = parseWeek(allWeeks[week]);
+              if (isNaN(currentWeek)) continue;
 
               inputData(
                 freeroomsData,
@@ -101,6 +102,12 @@ const getFreeroomsData = (req: express.Request, res: express.Response) => {
     res.status(400).send("Error");
   }
 };
+
+/**
+ * Parse week to integer.
+ * Converts weeks N1..N4 to 11..14
+ */
+const parseWeek = (week: string) => parseInt(week.replace("N", "1"));
 
 const inputData = (
   freeroomsData: {},
@@ -156,7 +163,7 @@ const toUTCString = (
 ) => {
   return DateTime.fromFormat(termStart + time, "dd/MM/yyyyHH:mm")
       .setZone("Australia/Sydney")
-      .plus({weeks: +week - 1})
+      .plus({weeks: week - 1})
       .set({weekday: DAYS.indexOf(day)})
       .toUTC()
       .toISO();

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -88,11 +88,6 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/luxon@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.2.0.tgz#99901b4ab29a5fdffc88fff59b3b47fbfbe0557b"
-  integrity sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==
-
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
@@ -206,6 +201,16 @@ cors@2.8.5:
   dependencies:
     object-assign "^4"
     vary "^1"
+
+date-fns-tz@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
+  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 debug@2.6.9:
   version "2.6.9"
@@ -377,11 +382,6 @@ lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
-
-luxon@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
-  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
 media-typer@0.3.0:
   version "0.3.0"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -202,15 +202,10 @@ cors@2.8.5:
     object-assign "^4"
     vary "^1"
 
-date-fns-tz@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
-  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
-
-date-fns@^2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
 
 debug@2.6.9:
   version "2.6.9"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -202,7 +202,7 @@ cors@2.8.5:
     object-assign "^4"
     vary "^1"
 
-dayjs@^1.11.7:
+dayjs@1.11.7:
   version "1.11.7"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
   integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -88,6 +88,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/luxon@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.2.0.tgz#99901b4ab29a5fdffc88fff59b3b47fbfbe0557b"
+  integrity sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==
+
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
@@ -372,6 +377,11 @@ lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
+luxon@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Modify the `/api/terms/:termId/freerooms` route to parse the class times into UTC and return as an ISO string to fix the bug in Freerooms. Uses dayjs library because I ceebs working with timezones and DST manually.

I've manually tested that:
- Route doesn't throw any errors where it didn't previously
- Route isn't unreasonably slow - about 250ms response time which is a bit worse than the previous 70ms but oh well
- The dates are correct - 22T1 Wk1 Mon goes to 14/2, 22T1 Wk8 Tue goes to 5/4
- It accounts for DST - 12:00 goes to 01:00 in Wk1 (during DST) but goes to 02:00 in Wk8 (outside DST)
- It works even when changing the timezone environment variable