### PR TITLE
fix(api): added cache control to force client to revalidate cache whe…

### DIFF
--- a/api/src/helpers/getTermDataInfo.ts
+++ b/api/src/helpers/getTermDataInfo.ts
@@ -32,6 +32,8 @@ const COURSE_OFFERED_EVERY_TERM = "ECON1101";
  */
 const getAvailableTermName = (req: express.Request, res: express.Response) => {
   try {
+    // forcing client to revalidate cache if data has changed
+    res.set('Cache-Control', 'must-revalidate');
     res.send(getLatestTermName());
   } catch (e) {
     res.status(400).send("Error");

--- a/api/src/notangles/index.ts
+++ b/api/src/notangles/index.ts
@@ -90,6 +90,8 @@ const getCourseList = (req: express.Request, res: express.Response) => {
         resCourses.courses.push(courseSummary);
       }
 
+      // forcing client to revalidate cache if data has changed
+      res.set('Cache-Control', 'must-revalidate');
       res.json(resCourses);
     } else {
       res.status(400).send(errorMessage);


### PR DESCRIPTION
Cache validation after each new scrape

Issue:
After each new term, users need to hard refresh to see some courses that were not previously there in their cache. Need to hard refresh localStorage, yet persist important data like the timetables and settings.