### PR TITLE
fix: update URL of subject list

### DIFF
--- a/scraper/src/scraper.ts
+++ b/scraper/src/scraper.ts
@@ -103,7 +103,7 @@ const timetableScraper = async (
     const courseWarnings: CourseWarning[] = [];
 
     // Go to the page with list of subjects (Accounting, Computers etc)
-    await page.goto(base, {
+    await page.goto(base + "subjectSearch.html", {
       waitUntil: "networkidle2",
     });
 


### PR DESCRIPTION
The scraper is broken !!!! This appears to be because the current base URL used to fetch the list of subjects (https://timetable.unsw.edu.au/2024/) no longer works and returns 404. Hit https://timetable.unsw.edu.au/2024/subjectSearch.html instead.